### PR TITLE
enable njit for count method on unicode type

### DIFF
--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -80,6 +80,10 @@ def find_usecase(x, y):
     return x.find(y)
 
 
+def count_usecase(x, y):
+    return x.count(y)
+
+
 def startswith_usecase(x, y):
     return x.startswith(y)
 
@@ -288,6 +292,16 @@ class TestUnicode(BaseTest):
                 self.assertEqual(pyfunc(a, substr),
                                  cfunc(a, substr),
                                  "'%s'.find('%s')?" % (a, substr))
+
+    def test_count(self, flags=no_pyobj_flags):
+        pyfunc = count_usecase
+        cfunc = njit(pyfunc)
+        for a in UNICODE_EXAMPLES:
+            extras = ['', 'xx', a[::-1], a[:-2], a[3:], a, a + a]
+            for substr in [x for x in extras]:
+                self.assertEqual(pyfunc(a, substr),
+                                 cfunc(a, substr),
+                                 "'%s'.count('%s')?" % (a, substr))
 
     def test_getitem(self):
         pyfunc = getitem_usecase
@@ -728,6 +742,17 @@ class TestUnicode(BaseTest):
             args = [a]
             self.assertEqual(pyfunc(*args), cfunc(*args),
                              msg='failed on {}'.format(args))
+
+    def test_literal_count(self):
+        def pyfunc(x):
+            return 'abc'.count(x), x.count('a')
+
+        cfunc = njit(pyfunc)
+        for a in ['ab', 'abc', 'abcd', '', 'c', 'abc' * 50]:
+            args = [a]
+            self.assertEqual(pyfunc(*args), cfunc(*args),
+                             msg='failed on {}'.format(args))
+
 
 
 @unittest.skipUnless(_py34_or_later,

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -375,6 +375,16 @@ def _find(substr, s):
     return -1
 
 
+@njit(_nrt=False)
+def _count(substr, s):
+    # Naive, slow string matching for now
+    count = 0
+    for i in range(len(s) - len(substr) + 1):
+        if _cmp_region(s, i, substr, 0, len(substr)) == 0:
+            count += 1
+    return count
+
+
 @njit
 def _is_whitespace(code_point):
     # list copied from https://github.com/python/cpython/blob/master/Objects/unicodetype_db.h
@@ -488,6 +498,14 @@ def unicode_contains(a, b):
             # note parameter swap: contains(a, b) == b in a
             return _find(substr=b, s=a) > -1
         return contains_impl
+
+
+@overload_method(types.UnicodeType, 'count')
+def unicode_count(a, b):
+    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+        def count_impl(a, b):
+            return _count(substr=b, s=a)
+        return count_impl
 
 
 @overload_method(types.UnicodeType, 'find')


### PR DESCRIPTION
Use the find method overload as a reference which uses naive string
matching. Add test cases that closely follow those of the find method as
well. However, add scenarios when testing the count method on literals
to fully cover comparison code paths.